### PR TITLE
Improve internals and add some features (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ encoded.
 options:
 
 - `forceFloat64`, a boolean to that forces all floats to be encoded as 64-bits floats. Defaults to false.
+- `sortKeys`, a boolean to force a determinate keys order
 - `compatibilityMode`, a boolean that enables "compatibility mode" which doesn't use str 8 format. Defaults to false.
 - `disableTimestampEncoding`, a boolean that when set disables the encoding of Dates into the [timestamp extension type](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type). Defaults to false.
 

--- a/lib/codecs/DateCodec.js
+++ b/lib/codecs/DateCodec.js
@@ -1,0 +1,62 @@
+const type = -1
+
+function encode (dt) {
+  var millis = dt * 1
+  var seconds = Math.floor(millis / 1000)
+  var nanos = (millis - seconds * 1000) * 1e6
+
+  if (nanos || seconds > 0xffffffff) {
+    // Timestamp64
+    const encoded = Buffer.allocUnsafe(9)
+    encoded[0] = -1
+
+    var upperNanos = nanos * 4
+    var upperSeconds = seconds / Math.pow(2, 32)
+    var upper = (upperNanos + upperSeconds) & 0xffffffff
+    var lower = seconds & 0xffffffff
+
+    encoded.writeInt32BE(upper, 1)
+    encoded.writeInt32BE(lower, 5)
+    return encoded
+  } else {
+    // Timestamp32
+    const encoded = Buffer.allocUnsafe(5)
+    encoded[0] = -1
+    encoded.writeUInt32BE(Math.floor(millis / 1000), 1)
+    return encoded
+  }
+}
+
+function check (obj) {
+  return typeof obj.getDate === 'function'
+}
+
+function decode (buf) {
+  var seconds
+  var nanoseconds = 0
+
+  switch (buf.length) {
+    case 4:
+      // timestamp 32 stores the number of seconds that have elapsed since 1970-01-01 00:00:00 UTC in an 32-bit unsigned integer
+      seconds = buf.readUInt32BE(0)
+      break
+
+    case 8:
+      // Timestamp 64 stores the number of seconds and nanoseconds that have elapsed
+      // since 1970-01-01 00:00:00 UTC in 32-bit unsigned integers, split 30/34 bits
+      var upper = buf.readUInt32BE(0)
+      var lower = buf.readUInt32BE(4)
+      nanoseconds = upper / 4
+      seconds = ((upper & 0x03) * Math.pow(2, 32)) + lower // If we use bitwise operators, we get truncated to 32bits
+      break
+
+    case 12:
+      throw new Error('timestamp 96 is not yet implemented')
+  }
+
+  var millis = (seconds * 1000) + Math.round(nanoseconds / 1E6)
+
+  return new Date(millis)
+}
+
+module.exports = { check, type, encode, decode }

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1,9 +1,7 @@
 'use strict'
 
 var bl = require('bl')
-var helpers = require('./helpers.js')
-var IncompleteBufferError = helpers.IncompleteBufferError
-var decodeTimestamp = helpers.decodeTimestamp
+var IncompleteBufferError = require('./helpers.js').IncompleteBufferError
 
 const SIZES = {
   0xc4: 2,
@@ -75,7 +73,7 @@ module.exports = function buildDecode (decodingTypes) {
       const length = first & 0x0f
       const headerSize = offset - initialOffset
       // we have an array with less than 15 elements
-      return decodeMap(buf, initialOffset, length, headerSize)
+      return decodeMap(buf, offset, length, headerSize)
     }
     if ((first & 0xf0) === 0x90) {
       const length = first & 0x0f
@@ -140,12 +138,12 @@ module.exports = function buildDecode (decodingTypes) {
           length = buf.readUInt16BE(offset)
           offset += 2
           // console.log(offset - initialOffset)
-          return decodeMap(buf, initialOffset, length, 3)
+          return decodeMap(buf, offset, length, 3)
 
         case 0xdf:
           length = buf.readUInt32BE(offset)
           offset += 4
-          return decodeMap(buf, initialOffset, length, 5)
+          return decodeMap(buf, offset, length, 5)
       }
     }
     if (first >= 0xe0) return [first - 0x100, 1] // 5 bits negative ints
@@ -168,24 +166,36 @@ module.exports = function buildDecode (decodingTypes) {
     return [result, headerLength + offset - initialOffset]
   }
 
-  function decodeMap (buf, initialOffset, length, headerLength) {
-    var offset = initialOffset + headerLength
-    const result = {}
-    var i = 0
+  function decodeMap (buf, offset, length, headerLength) {
+    const _temp = decodeArray(buf, offset, 2 * length, headerLength)
+    if (!_temp) return null
+    const [ result, consumedBytes ] = _temp
 
-    while (i++ < length) {
-      var keyResult = tryDecode(buf, offset)
-      if (!keyResult) return null
-      offset += keyResult[1]
-
-      var valueResult = tryDecode(buf, offset)
-      if (!valueResult) return null
-      offset += valueResult[1]
-
-      result[keyResult[0]] = valueResult[0]
+    var isPlainObject = true
+    for (let i = 0; i < 2 * length; i += 2) {
+      if (typeof result[i] !== 'string') {
+        isPlainObject = false
+        break
+      }
     }
 
-    return [result, offset - initialOffset]
+    if (isPlainObject) {
+      const object = {}
+      for (let i = 0; i < 2 * length; i += 2) {
+        const key = result[i]
+        const val = result[i + 1]
+        object[key] = val
+      }
+      return [object, consumedBytes]
+    } else {
+      const mapping = new Map()
+      for (let i = 0; i < 2 * length; i += 2) {
+        const key = result[i]
+        const val = result[i + 1]
+        mapping.set(key, val)
+      }
+      return [mapping, consumedBytes]
+    }
   }
 
   function readInt64BE (buf, offset) {
@@ -237,10 +247,7 @@ module.exports = function buildDecode (decodingTypes) {
   function decodeExt (buf, offset, type, size, headerSize) {
     const toDecode = buf.slice(offset, offset + size)
 
-    // Pre-defined  (type < 0) Reserved for future extensions
-    if (type === -1) return decodeTimestamp(toDecode, size, headerSize)
-
-    const decode = decodingTypes[type]
+    const decode = decodingTypes.get(type)
     if (!decode) throw new Error('unable to find ext type ' + type)
 
     var value = decode(toDecode)

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -2,334 +2,122 @@
 
 var Buffer = require('safe-buffer').Buffer
 var bl = require('bl')
+var isNaN = require('./helpers.js').isNaN
+var isFloat = require('./helpers.js').isFloat
 
-module.exports = function buildEncode (encodingTypes, forceFloat64, compatibilityMode, disableTimestampEncoding) {
-  function encode (obj, avoidSlice) {
-    var buf
-    var len
+module.exports = function buildEncode (encodingTypes, options) {
+  function encode (obj) {
+    if (obj === undefined) throw new Error('undefined is not encodable in msgpack!')
+    if (isNaN(obj)) throw new Error('NaN is not encodable in msgpack!')
 
-    if (obj === undefined) {
-      throw new Error('undefined is not encodable in msgpack!')
-    } else if (isNaN(obj)) {
-      throw new Error('NaN is not encodable in msgpack!')
-    } else if (obj === null) {
-      buf = Buffer.allocUnsafe(1)
-      buf[0] = 0xc0
-    } else if (obj === true) {
-      buf = Buffer.allocUnsafe(1)
-      buf[0] = 0xc3
-    } else if (obj === false) {
-      buf = Buffer.allocUnsafe(1)
-      buf[0] = 0xc2
-    } else if (typeof obj === 'string') {
-      len = Buffer.byteLength(obj)
-      if (len < 32) {
-        buf = Buffer.allocUnsafe(1 + len)
-        buf[0] = 0xa0 | len
-        if (len > 0) {
-          buf.write(obj, 1)
-        }
-      } else if (len <= 0xff && !compatibilityMode) {
-        // str8, but only when not in compatibility mode
-        buf = Buffer.allocUnsafe(2 + len)
-        buf[0] = 0xd9
-        buf[1] = len
-        buf.write(obj, 2)
-      } else if (len <= 0xffff) {
-        buf = Buffer.allocUnsafe(3 + len)
-        buf[0] = 0xda
-        buf.writeUInt16BE(len, 1)
-        buf.write(obj, 3)
-      } else {
-        buf = Buffer.allocUnsafe(5 + len)
-        buf[0] = 0xdb
-        buf.writeUInt32BE(len, 1)
-        buf.write(obj, 5)
-      }
-    } else if (obj && (obj.readUInt32LE || obj instanceof Uint8Array)) {
+    if (obj === null) return Buffer.from([ 0xc0 ])
+    if (obj === true) return Buffer.from([ 0xc3 ])
+    if (obj === false) return Buffer.from([ 0xc2 ])
+
+    if (obj instanceof Map) return encodeMap(obj, options, encode)
+
+    if (typeof obj === 'string') return encodeString(obj, options)
+
+    if (obj && (obj.readUInt32LE || obj instanceof Uint8Array)) {
       if (obj instanceof Uint8Array) {
         obj = Buffer.from(obj)
       }
       // weird hack to support Buffer
       // and Buffer-like objects
-      if (obj.length <= 0xff) {
-        buf = Buffer.allocUnsafe(2)
-        buf[0] = 0xc4
-        buf[1] = obj.length
-      } else if (obj.length <= 0xffff) {
-        buf = Buffer.allocUnsafe(3)
-        buf[0] = 0xc5
-        buf.writeUInt16BE(obj.length, 1)
-      } else {
-        buf = Buffer.allocUnsafe(5)
-        buf[0] = 0xc6
-        buf.writeUInt32BE(obj.length, 1)
-      }
-
-      buf = bl([buf, obj])
-    } else if (Array.isArray(obj)) {
-      if (obj.length < 16) {
-        buf = Buffer.allocUnsafe(1)
-        buf[0] = 0x90 | obj.length
-      } else if (obj.length < 65536) {
-        buf = Buffer.allocUnsafe(3)
-        buf[0] = 0xdc
-        buf.writeUInt16BE(obj.length, 1)
-      } else {
-        buf = Buffer.allocUnsafe(5)
-        buf[0] = 0xdd
-        buf.writeUInt32BE(obj.length, 1)
-      }
-
-      buf = obj.reduce(function (acc, obj) {
-        acc.append(encode(obj, true))
-        return acc
-      }, bl().append(buf))
-    } else if (!disableTimestampEncoding && typeof obj.getDate === 'function') {
-      return encodeDate(obj)
-    } else if (typeof obj === 'object') {
-      buf = encodeExt(obj) || encodeObject(obj)
-    } else if (typeof obj === 'number') {
-      if (isFloat(obj)) {
-        return encodeFloat(obj, forceFloat64)
-      } else if (obj >= 0) {
-        if (obj < 128) {
-          buf = Buffer.allocUnsafe(1)
-          buf[0] = obj
-        } else if (obj < 256) {
-          buf = Buffer.allocUnsafe(2)
-          buf[0] = 0xcc
-          buf[1] = obj
-        } else if (obj < 65536) {
-          buf = Buffer.allocUnsafe(3)
-          buf[0] = 0xcd
-          buf.writeUInt16BE(obj, 1)
-        } else if (obj <= 0xffffffff) {
-          buf = Buffer.allocUnsafe(5)
-          buf[0] = 0xce
-          buf.writeUInt32BE(obj, 1)
-        } else if (obj <= 9007199254740991) {
-          buf = Buffer.allocUnsafe(9)
-          buf[0] = 0xcf
-          write64BitUint(buf, obj)
-        } else {
-          return encodeFloat(obj, true)
-        }
-      } else {
-        if (obj >= -32) {
-          buf = Buffer.allocUnsafe(1)
-          buf[0] = 0x100 + obj
-        } else if (obj >= -128) {
-          buf = Buffer.allocUnsafe(2)
-          buf[0] = 0xd0
-          buf.writeInt8(obj, 1)
-        } else if (obj >= -32768) {
-          buf = Buffer.allocUnsafe(3)
-          buf[0] = 0xd1
-          buf.writeInt16BE(obj, 1)
-        } else if (obj > -214748365) {
-          buf = Buffer.allocUnsafe(5)
-          buf[0] = 0xd2
-          buf.writeInt32BE(obj, 1)
-        } else if (obj >= -9007199254740991) {
-          buf = Buffer.allocUnsafe(9)
-          buf[0] = 0xd3
-          write64BitInt(buf, 1, obj)
-        } else {
-          return encodeFloat(obj, true)
-        }
-      }
+      return bl([getBufferHeader(obj.length), obj])
     }
+    if (Array.isArray(obj)) return bl().append([ getHeader(obj.length, 0x90, 0xdc), ...obj.map(encode) ])
+    if (typeof obj === 'object') return encodeExt(obj, encodingTypes) || encodeObject(obj, options, encode)
+    if (typeof obj === 'number') return encodeNumber(obj, options)
 
-    if (!buf) {
-      throw new Error('not implemented yet')
-    }
-
-    if (avoidSlice) {
-      return buf
-    } else {
-      return buf.slice()
-    }
+    throw new Error('not implemented yet')
   }
 
-  function encodeDate (dt) {
-    var encoded
-    var millis = dt * 1
-    var seconds = Math.floor(millis / 1000)
-    var nanos = (millis - (seconds * 1000)) * 1E6
-
-    if (nanos || seconds > 0xFFFFFFFF) {
-      // Timestamp64
-      encoded = Buffer.allocUnsafe(10)
-      encoded[0] = 0xd7
-      encoded[1] = -1
-
-      var upperNanos = ((nanos * 4))
-      var upperSeconds = seconds / Math.pow(2, 32)
-      var upper = (upperNanos + upperSeconds) & 0xFFFFFFFF
-      var lower = seconds & 0xFFFFFFFF
-
-      encoded.writeInt32BE(upper, 2)
-      encoded.writeInt32BE(lower, 6)
-    } else {
-      // Timestamp32
-      encoded = Buffer.allocUnsafe(6)
-      encoded[0] = 0xd6
-      encoded[1] = -1
-      encoded.writeUInt32BE(Math.floor(millis / 1000), 2)
-    }
-    return bl().append(encoded)
+  return function (obj) {
+    return encode(obj).slice()
   }
-
-  function encodeExt (obj) {
-    var i
-    var encoded
-    var length = -1
-    var headers = []
-
-    for (i = 0; i < encodingTypes.length; i++) {
-      if (encodingTypes[i].check(obj)) {
-        encoded = encodingTypes[i].encode(obj)
-        break
-      }
-    }
-
-    if (!encoded) {
-      return null
-    }
-
-    // we subtract 1 because the length does not
-    // include the type
-    length = encoded.length - 1
-
-    if (length === 1) {
-      headers.push(0xd4)
-    } else if (length === 2) {
-      headers.push(0xd5)
-    } else if (length === 4) {
-      headers.push(0xd6)
-    } else if (length === 8) {
-      headers.push(0xd7)
-    } else if (length === 16) {
-      headers.push(0xd8)
-    } else if (length < 256) {
-      headers.push(0xc7)
-      headers.push(length)
-    } else if (length < 0x10000) {
-      headers.push(0xc8)
-      headers.push(length >> 8)
-      headers.push(length & 0x00ff)
-    } else {
-      headers.push(0xc9)
-      headers.push(length >> 24)
-      headers.push((length >> 16) & 0x000000ff)
-      headers.push((length >> 8) & 0x000000ff)
-      headers.push(length & 0x000000ff)
-    }
-
-    return bl().append(Buffer.from(headers)).append(encoded)
-  }
-
-  function encodeObject (obj) {
-    var acc = []
-    var length = 0
-    var key
-    var header
-
-    for (key in obj) {
-      if (obj.hasOwnProperty(key) &&
-        obj[key] !== undefined &&
-        typeof obj[key] !== 'function') {
-        ++length
-        acc.push(encode(key, true))
-        acc.push(encode(obj[key], true))
-      }
-    }
-
-    if (length < 16) {
-      header = Buffer.allocUnsafe(1)
-      header[0] = 0x80 | length
-    } else if (length < 0xFFFF) {
-      header = Buffer.allocUnsafe(3)
-      header[0] = 0xde
-      header.writeUInt16BE(length, 1)
-    } else {
-      header = Buffer.allocUnsafe(5)
-      header[0] = 0xdf
-      header.writeUInt32BE(length, 1)
-    }
-
-    acc.unshift(header)
-
-    var result = acc.reduce(function (list, buf) {
-      return list.append(buf)
-    }, bl())
-
-    return result
-  }
-
-  return encode
 }
 
-function write64BitUint (buf, obj) {
-  // Write long byte by byte, in big-endian order
-  for (var currByte = 7; currByte >= 0; currByte--) {
-    buf[currByte + 1] = (obj & 0xff)
-    obj = obj / 256
+//
+//
+// === MENTAL SEPARATOR ===
+//
+//
+
+function encodeMap (map, options, encode) {
+  const acc = [ getHeader(map.size, 0x80, 0xde) ]
+  const keys = [ ...map.keys() ]
+
+  if (keys.every(item => typeof item === 'string')) {
+    console.warn('Map with string only keys will be deserialized as an object!')
   }
+
+  keys.forEach(key => {
+    acc.push(encode(key), encode(map.get(key)))
+  })
+  return bl(acc)
+}
+
+function encodeObject (obj, options, encode) {
+  var keys = []
+
+  for (let key in obj) {
+    if (obj.hasOwnProperty(key) &&
+        obj[key] !== undefined &&
+        typeof obj[key] !== 'function') {
+      keys.push(key)
+    }
+  }
+
+  const acc = [ getHeader(keys.length, 0x80, 0xde) ]
+
+  if (options.sortKeys) keys.sort()
+
+  keys.forEach(key => {
+    acc.push(encode(key), encode(obj[key]))
+  })
+
+  return bl(acc)
+}
+
+function write64BitUint (buf, offset, num) {
+  var lo = num % 4294967296
+  var hi = Math.floor(num / 4294967296)
+
+  buf.writeUInt32BE(hi, offset + 0)
+  buf.writeUInt32BE(lo, offset + 4)
 }
 
 function write64BitInt (buf, offset, num) {
   var negate = num < 0
+  num = Math.abs(num)
+  write64BitUint(buf, offset, num)
+  if (negate) negate64BitInt(buf, offset)
+}
 
-  if (negate) {
-    num = Math.abs(num)
+function negate64BitInt (buf, offset) {
+  var i = offset + 8
+
+  // Optimization based on the fact that:
+  // buf[i] == 0x00  => (buf[i] ^ 0xff) + 1 = 0x100 = 0x00 + 1 curry
+
+  while (i-- > offset) {
+    if (buf[i] === 0x00) continue
+    buf[i] = (buf[i] ^ 0xff) + 1
+    break
   }
 
-  var lo = num % 4294967296
-  var hi = num / 4294967296
-  buf.writeUInt32BE(Math.floor(hi), offset + 0)
-  buf.writeUInt32BE(lo, offset + 4)
-
-  if (negate) {
-    var carry = 1
-    for (var i = offset + 7; i >= offset; i--) {
-      var v = (buf[i] ^ 0xff) + carry
-      buf[i] = v & 0xff
-      carry = v >> 8
-    }
+  while (i-- > offset) {
+    buf[i] = buf[i] ^ 0xff
   }
 }
 
-function isFloat (n) {
-  return n % 1 !== 0
-}
-
-function isNaN (n) {
-  /* eslint-disable no-self-compare */
-  return n !== n && typeof n === 'number'
-  /* eslint-enable no-self-compare */
-}
+const fround = Math.fround
 
 function encodeFloat (obj, forceFloat64) {
-  var useDoublePrecision = true
-
-  // If `fround` is supported, we can check if a float
-  // is double or single precision by rounding the object
-  // to single precision and comparing the difference.
-  // If it's not supported, it's safer to use a 64 bit
-  // float so we don't lose precision without meaning to.
-  if (Math.fround) {
-    useDoublePrecision = Math.fround(obj) !== obj
-  }
-
-  if (forceFloat64) {
-    useDoublePrecision = true
-  }
-
   var buf
 
-  if (useDoublePrecision) {
+  if (forceFloat64 || !fround || fround(obj) !== obj) {
     buf = Buffer.allocUnsafe(9)
     buf[0] = 0xcb
     buf.writeDoubleBE(obj, 1)
@@ -341,3 +129,133 @@ function encodeFloat (obj, forceFloat64) {
 
   return buf
 }
+
+function encodeExt (obj, encodingTypes) {
+  const codec = encodingTypes.find(codec => codec.check(obj))
+  if (!codec) return null
+  const encoded = codec.encode(obj)
+  if (!encoded) return null
+
+  return bl([ getExtHeader(encoded.length - 1), encoded ])
+}
+
+function getExtHeader (length) {
+  if (length === 1) return Buffer.from([ 0xd4 ])
+  if (length === 2) return Buffer.from([ 0xd5 ])
+  if (length === 4) return Buffer.from([ 0xd6 ])
+  if (length === 8) return Buffer.from([ 0xd7 ])
+  if (length === 16) return Buffer.from([ 0xd8 ])
+
+  if (length < 256) return Buffer.from([ 0xc7, length ])
+  if (length < 0x10000) return Buffer.from([ 0xc8, length >> 8, length & 0x00ff ])
+  return Buffer.from([ 0xc9, length >> 24, (length >> 16) & 0x000000ff, (length >> 8) & 0x000000ff, length & 0x000000ff ])
+}
+
+function getHeader (length, tag1, tag2) {
+  if (length < 16) return Buffer.from([ tag1 | length ])
+  const size = length < 0x10000 ? 2 : 4
+  var buf = Buffer.allocUnsafe(1 + size)
+  buf[0] = length < 0x10000 ? tag2 : tag2 + 1
+  buf.writeUIntBE(length, 1, size)
+
+  return buf
+}
+
+function encodeString (obj, options) {
+  const len = Buffer.byteLength(obj)
+  var buf
+  if (len < 32) {
+    buf = Buffer.allocUnsafe(1 + len)
+    buf[0] = 0xa0 | len
+    if (len > 0) {
+      buf.write(obj, 1)
+    }
+  } else if (len <= 0xff && !options.compatibilityMode) {
+    // str8, but only when not in compatibility mode
+    buf = Buffer.allocUnsafe(2 + len)
+    buf[0] = 0xd9
+    buf[1] = len
+    buf.write(obj, 2)
+  } else if (len <= 0xffff) {
+    buf = Buffer.allocUnsafe(3 + len)
+    buf[0] = 0xda
+    buf.writeUInt16BE(len, 1)
+    buf.write(obj, 3)
+  } else {
+    buf = Buffer.allocUnsafe(5 + len)
+    buf[0] = 0xdb
+    buf.writeUInt32BE(len, 1)
+    buf.write(obj, 5)
+  }
+  return buf
+}
+
+function getBufferHeader (length) {
+  var header
+  if (length <= 0xff) {
+    header = Buffer.allocUnsafe(2)
+    header[0] = 0xc4
+    header[1] = length
+  } else if (length <= 0xffff) {
+    header = Buffer.allocUnsafe(3)
+    header[0] = 0xc5
+    header.writeUInt16BE(length, 1)
+  } else {
+    header = Buffer.allocUnsafe(5)
+    header[0] = 0xc6
+    header.writeUInt32BE(length, 1)
+  }
+
+  return header
+}
+
+function encodeNumber (obj, options) {
+  var buf
+  if (isFloat(obj)) return encodeFloat(obj, options.forceFloat64)
+  if (Math.abs(obj) > 9007199254740991) {
+    return encodeFloat(obj, true)
+  }
+
+  if (obj >= 0) {
+    if (obj < 128) {
+      return Buffer.from([ obj ])
+    } else if (obj < 256) {
+      return Buffer.from([ 0xcc, obj ])
+    } else if (obj < 65536) {
+      return Buffer.from([ 0xcd, 0xff & (obj >> 8), 0xff & (obj) ])
+    } else if (obj <= 0xffffffff) {
+      return Buffer.from([ 0xce, 0xff & (obj >> 24), 0xff & (obj >> 16), 0xff & (obj >> 8), 0xff & (obj) ])
+    } else if (obj <= 9007199254740991) {
+      buf = Buffer.allocUnsafe(9)
+      buf[0] = 0xcf
+      write64BitUint(buf, 1, obj)
+    }
+  } else {
+    if (obj >= -32) {
+      buf = Buffer.allocUnsafe(1)
+      buf[0] = 0x100 + obj
+    } else if (obj >= -128) {
+      buf = Buffer.allocUnsafe(2)
+      buf[0] = 0xd0
+      buf.writeInt8(obj, 1)
+    } else if (obj >= -32768) {
+      buf = Buffer.allocUnsafe(3)
+      buf[0] = 0xd1
+      buf.writeInt16BE(obj, 1)
+    } else if (obj > -214748365) {
+      buf = Buffer.allocUnsafe(5)
+      buf[0] = 0xd2
+      buf.writeInt32BE(obj, 1)
+    } else if (obj >= -9007199254740991) {
+      buf = Buffer.allocUnsafe(9)
+      buf[0] = 0xd3
+      write64BitInt(buf, 1, obj)
+    }
+  }
+  return buf
+}
+
+// function order(num, n = 1, step = 2) {
+//    while (num = num >> step) n++;
+//    return n
+// }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,8 +2,6 @@
 
 var util = require('util')
 
-const fround = Math.fround
-
 exports.IncompleteBufferError = IncompleteBufferError
 
 function IncompleteBufferError (message) {
@@ -25,48 +23,4 @@ exports.isNaN = function isNaN (n) {
   /* eslint-disable no-self-compare */
   return n !== n && typeof n === 'number'
   /* eslint-enable no-self-compare */
-}
-
-exports.encodeFloat = function encodeFloat (obj, forceFloat64) {
-  var buf
-
-  if (forceFloat64 || !fround || fround(obj) !== obj) {
-    buf = Buffer.allocUnsafe(9)
-    buf[0] = 0xcb
-    buf.writeDoubleBE(obj, 1)
-  } else {
-    buf = Buffer.allocUnsafe(5)
-    buf[0] = 0xca
-    buf.writeFloatBE(obj, 1)
-  }
-
-  return buf
-}
-
-exports.decodeTimestamp = function decodeTimestamp (buf, size, headerSize) {
-  var seconds
-  var nanoseconds = 0
-
-  switch (size) {
-    case 4:
-      // timestamp 32 stores the number of seconds that have elapsed since 1970-01-01 00:00:00 UTC in an 32-bit unsigned integer
-      seconds = buf.readUInt32BE(0)
-      break
-
-    case 8:
-      // Timestamp 64 stores the number of seconds and nanoseconds that have elapsed
-      // since 1970-01-01 00:00:00 UTC in 32-bit unsigned integers, split 30/34 bits
-      var upper = buf.readUInt32BE(0)
-      var lower = buf.readUInt32BE(4)
-      nanoseconds = upper / 4
-      seconds = ((upper & 0x03) * Math.pow(2, 32)) + lower // If we use bitwise operators, we get truncated to 32bits
-      break
-
-    case 12:
-      throw new Error('timestamp 96 is not yet implemented')
-  }
-
-  var millis = (seconds * 1000) + Math.round(nanoseconds / 1E6)
-
-  return [ new Date(millis), size + headerSize ]
 }

--- a/test/map-with-object-key.js
+++ b/test/map-with-object-key.js
@@ -1,0 +1,25 @@
+'use strict'
+
+var Buffer = require('safe-buffer').Buffer
+var test = require('tape').test
+var msgpack = require('../')
+
+test('encode/decode map with multiple short buffers as both keys and values', function (t) {
+  const first = Buffer.from('first')
+  const second = Buffer.from('second')
+  const third = Buffer.from('third')
+
+  const mapping = new Map().set(first, second)
+    .set(second, third)
+    .set(third, first)
+
+  var pack = msgpack()
+
+  const newMapping = pack.decode(pack.encode(mapping))
+
+  t.equals(newMapping.size, mapping.size)
+  t.deepEqual([ ...newMapping.keys() ], [ ...mapping.keys() ])
+  t.deepEqual([ ...newMapping.values() ], [ ...mapping.values() ])
+
+  t.end()
+})


### PR DESCRIPTION
* Feature: Manually encode unsuppoted object.

* Refactoring: inlining hasMinBufferSize and simplifying decode(buf)

Changes to be committed:
  modified:   lib/decoder.js

* Used while where it actually meant to.

* In decodeMap(...) simplify counting amount of bytes consumed

Well, provided that initialOffset is the value passed as an argument:
console.log(headerLength + totalBytesConsumed === offset - initialOffset)
// true   --- always

* Imporove maintainability

1. getSize now is implemented through hash not switch statement.
   More concise and appear to be much faster.

2. Created helpers.js file, and functions that logically unrelated
   to decoding/encoding will go there.

3. Where possible prefer flat code that nested branches

4. In decodeExt dramatically simplify all the things.

Changes to be committed:
	modified:   lib/decoder.js
	new file:   lib/helpers.js

* Getting rid of "offset + 1" artificial expression

It's caused by not incrementing offset after reaading first byte.
To handle this change I first of all introduce "initialOffset" and
change everywhere offset to "initial offset". This commit does
this part of the job.

Then I will clean 1-by-1 every affected function and branch.

* Keep on getting intent more clear

1. Remove "else" statements that go after "return"
2. Where appropriate (another 1-4 bytes have been read) offset is incremented
3. So that expressions like "initialOffset + 2" --- "... + 5" could be replaced by just "offset"

Changes to be committed:
  modified:   lib/decoder.js

* Implemented all integers and all kinds of floats

1. function decodeSigned (buf, offset, size)
2. function decodeFloat (buf, offset, size)
3. function decodeExt (buf, offset, type, size, headerSize)

* Added missing Ranges as TODO commends

Currently:

| RANGE      |  STATUS             | function name (if exists) or type name  |
|------------|---------------------|-----------------|
| 0x00, 0x7f |  MISSING COMPLETELY | positive fixint
| 0x80, 0x8f |  MISSING COMPLETELY | fixmap
| 0x90, 0x9f |  MISSING COMPLETELY | fixarr
| 0xa0, 0xbf |  MISSING COMPLETELY | fixstr
| 0xc0, 0xc3 |  DONE               | decodeConstants(...)
| 0xc4, 0xc6 |  OLD CODE           | decodeBuffers(...)
| 0xc7, 0xc9 |  WIP NOW            | decodeExt(...)
| 0xca, 0xcb |  DONE               | decodeFloat
| 0xcc, 0xcf |  DONE               | decodeUnsignedInt()
| 0xd0, 0xd3 |  DONE               | decodeSigned()
| 0xd4, 0xd8 |  DONE               | decodeFixExt()
| 0xd9, 0xdb |  OLD CODE           | decodeStr(...)
| 0xdc, 0xdd |  OLD CODE           | decodeArray(...)
| 0xde, 0xdf |  OLD CODE           | decodeMap(...)
| 0xe0, 0xff |  MISSING COMPLETELY | negative fixint

* function decodeStr (buf, offset, size)

* Added decodeBuffers

* gitignore updated

* if (inRange(0xc7, 0xc9)) return decodeExts(buf, offset, size - 2)

* decodeFixExt + Moved functions outside of closure

* It was just a line!

* Update .gitignore

* decodeArray

* small arrays and

* decodeMaps + ordering

* fixmap fixarr fixstr

* Inline buf.readUIntBE(offset, size) method where getLength (buf, offset, size) used

* function decodeTimestamp (buf, size, headerSize) moved to helper

* Use array syntax to handle results

* Few changes

* Avoid using length var at top level

* Avoid using result var at top level

* remove dist folder from git

* Restore dist files

* Restore dist min files

* Finally restore min version

* Inline decodeExts helper

* Revert transform unsupported

* Clean up index.js

* Import IncompleteBufferError from helpers.js and not reexport in decoder.js

* Remove passing transformUnsupported option from index.js

* Small fixes

* Small fixes

* Fix travis builds

* Fix travis builds 2

* Fix travis builds 3

* function getHeaders

* function getHeader

* move some functions out of closure

* Better handling of TimestampEncoding

* encodeFloat function simplified

* Feature: Sort Keys

* Feature: support encoding/decoding Maps

* Feature: support encoding/decoding Maps

* Test descr updated

* Move all Timestamp-related into separate file

* Use bl constuctor instead of append method

* Unify headers methods

* Import helpers from helpers.js

* fix build

* restructure DataCodec module